### PR TITLE
fix(android): inject useCLLocationAccuracy into params before every u…

### DIFF
--- a/android/src/main/java/com/transistorsoft/bggeo/capacitor/BackgroundGeolocationPlugin.java
+++ b/android/src/main/java/com/transistorsoft/bggeo/capacitor/BackgroundGeolocationPlugin.java
@@ -194,6 +194,7 @@ public class BackgroundGeolocationPlugin extends Plugin {
     public void setConfig(PluginCall call) throws JSONException {
         TSConfig config = TSConfig.getInstance(getContext());
         JSObject params = call.getObject("options");
+        params.put("useCLLocationAccuracy", true);
         config.updateWithJSONObject(params);
         call.resolve(JSObject.fromJSONObject(config.toJson(false)));
     }
@@ -989,6 +990,7 @@ public class BackgroundGeolocationPlugin extends Plugin {
 
     private JSONObject setHeadlessJobService(JSObject params) {
         params.put("headlessJobService", getHeadlessJobService());
+        params.put("useCLLocationAccuracy", true);
         return params;
     }
 


### PR DESCRIPTION
…pdateWithJSONObject call

config.reset() in ready() wipes GeoState.useCLLocationAccuracy back to false, and the subsequent setUseCLLocationAccuracy(true) is a no-op due to the RuntimeState early-exit guard. This causes CL-style desiredAccuracy values (-1, -2, etc.) to pass through untranslated to LocationRequest.setPriority(), crashing on play-services-location v21+.

Inject useCLLocationAccuracy:true into the params JSONObject at every updateWithJSONObject call site so the flag survives config.reset().